### PR TITLE
Add type for SDMX period

### DIFF
--- a/v2_1/ws/rest/src/sdmx-rest.yaml
+++ b/v2_1/ws/rest/src/sdmx-rest.yaml
@@ -223,7 +223,7 @@ paths:
           
 components:
   schemas:
-    sdmxPeriod:
+    SdmxPeriod:
       type: string
       pattern: '^\d{4}-?((\d{2}(-\d{2})?)|A1|S[1|2]|Q[1-4]|T[1-3]|M(0[1-9]|1[0-2])|W(0[1-9]|[1-4][0-9]|5[0-3])|D(0[0-9][1-9]|[1-2][0-9][0-9]|3[0-5][0-9]|36[0-6]))?$'
       description: |

--- a/v2_1/ws/rest/src/sdmx-rest.yaml
+++ b/v2_1/ws/rest/src/sdmx-rest.yaml
@@ -429,7 +429,7 @@ components:
         The end of the period for which results should be supplied (inclusive).
       required: false
       schema:
-        $ref: '#/components/schemas/sdmxPeriod'
+        $ref: '#/components/schemas/SdmxPeriod'
     updatedAfter:
       in: query
       name: updatedAfter

--- a/v2_1/ws/rest/src/sdmx-rest.yaml
+++ b/v2_1/ws/rest/src/sdmx-rest.yaml
@@ -421,7 +421,7 @@ components:
         The start of the period for which results should be supplied (inclusive).
       required: false
       schema:
-        $ref: '#/components/schemas/sdmxPeriod'
+        $ref: '#/components/schemas/SdmxPeriod'
     endPeriod:
       in: query
       name: endPeriod

--- a/v2_1/ws/rest/src/sdmx-rest.yaml
+++ b/v2_1/ws/rest/src/sdmx-rest.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.0.0'
+  version: "2.0.0-SNAPSHOT"
   title: 'SDMX RESTful API, v2.0.0'
   description: |
     The SDMX RESTful API, released in XXX 2020.
@@ -222,6 +222,21 @@ paths:
           $ref: '#/components/responses/503'
           
 components:
+  schemas:
+    sdmxPeriod:
+      type: string
+      pattern: '^\d{4}-?((\d{2}(-\d{2})?)|A1|S[1|2]|Q[1-4]|T[1-3]|M(0[1-9]|1[0-2])|W(0[1-9]|[1-4][0-9]|5[0-3])|D(0[0-9][1-9]|[1-2][0-9][0-9]|3[0-5][0-9]|36[0-6]))?$'
+      description: |
+        The start of the period for which results should be supplied (inclusive).
+        
+        Can be expressed using 8601 dates or SDMX reporting periods. 
+        
+        Examples:
+        * `2000`: Year (ISO 8601)
+        * `2000-01`: Month (ISO 8601)
+        * `2000-01-01`: Date (ISO 8601)
+        * `2000-Q1`: Quarter (SDMX)
+        * `2000-W01`: Week (SDMX)
   parameters:
     flow:
       in: path
@@ -404,38 +419,17 @@ components:
       name: startPeriod
       description: |
         The start of the period for which results should be supplied (inclusive).
-        
-        Can be expressed using 8601 dates or SDMX reporting periods. 
-        
-        Examples:
-        * `2000`: Year (ISO 8601)
-        * `2000-01`: Month (ISO 8601)
-        * `2000-01-01`: Date (ISO 8601)
-        * `2000-Q1`: Quarter (SDMX)
-        * `2000-W01`: Week (SDMX)
-        
       required: false
       schema:
-        type: string
-        pattern: '^\d{4}-?((\d{2}(-\d{2})?)|A1|S[1|2]|Q[1-4]|T[1-3]|M(0[1-9]|1[0-2])|W(0[1-9]|[1-4][0-9]|5[0-3])|D(0[0-9][1-9]|[1-2][0-9][0-9]|3[0-5][0-9]|36[0-6]))?$'
+        $ref: '#/components/schemas/sdmxPeriod'
     endPeriod:
       in: query
       name: endPeriod
       description: |
         The end of the period for which results should be supplied (inclusive).
-        
-        Can be expressed using 8601 dates or SDMX reporting periods. 
-        
-        Examples:
-        * `2000`: Year (ISO 8601)
-        * `2000-01`: Month (ISO 8601)
-        * `2000-01-01`: Date (ISO 8601)
-        * `2000-S1`: Semester (SDMX)
-        * `2000-D001`: Day (SDMX)
       required: false
       schema:
-        type: string
-        pattern: '^\d{4}-?((\d{2}(-\d{2})?)|A1|S[1|2]|Q[1-4]|T[1-3]|M(0[1-9]|1[0-2])|W(0[1-9]|[1-4][0-9]|5[0-3])|D(0[0-9][1-9]|[1-2][0-9][0-9]|3[0-5][0-9]|36[0-6]))?$'
+        $ref: '#/components/schemas/sdmxPeriod'
     updatedAfter:
       in: query
       name: updatedAfter


### PR DESCRIPTION
As proposed by @ioggstream (thanks, @ioggstream!), a type for SDMX periods has been introduced in the Open API definition and is now reused by both start and endPeriod.

Fix #102 