### PR TITLE
Change response type for availability queries

### DIFF
--- a/v2_1/ws/rest/src/sdmx-rest.yaml
+++ b/v2_1/ws/rest/src/sdmx-rest.yaml
@@ -86,7 +86,7 @@ paths:
       responses:
         <<: *common_responses
         '200':
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/200-struct'
 
   /structure/{structureType}/{agencyID}/{resourceID}/{version}:
     get:


### PR DESCRIPTION
The availability query is currently defined so as to return data (`#/components/responses/200`). It should be a structure instead (`#/components/responses/200-struct`).