### PR TITLE
Fix 2 issues with schema queries

### DIFF
--- a/api/sdmx-rest.yaml
+++ b/api/sdmx-rest.yaml
@@ -122,7 +122,6 @@ paths:
         - $ref: '#/components/parameters/resourceID'
         - $ref: '#/components/parameters/version'
         - $ref: '#/components/parameters/dimensionAtObservation'
-        - $ref: '#/components/parameters/explicitMeasure'
         - $ref: '#/components/parameters/accept-encoding'
         - $ref: '#/components/parameters/if-modified-since'
       responses:
@@ -561,14 +560,6 @@ components:
       name: includeHistory
       description: |
         This attribute allows retrieving previous versions of the data, as they were disseminated in the past (*history* or *timeline* functionality).
-      required: false
-      schema:
-        type: boolean
-        default: false
-    explicitMeasure:
-      in: query
-      name: explicitMeasure
-      description: For cross-sectional data validation, indicates whether observations are strongly typed.
       required: false
       schema:
         type: boolean

--- a/api/sdmx-rest.yaml
+++ b/api/sdmx-rest.yaml
@@ -345,6 +345,7 @@ components:
             dataflow,
             metadataflow,
             provisionagreement,
+            metadataprovisionagreement,
           ]
     agencyID:
       in: path


### PR DESCRIPTION
The OpenAPI definition is not in line with the documentation.

- `explicitMeasure` should no longer be supported;
- `metadataprovisionagreement` should be a valid context for schema queries.

Close #169