### PR TITLE
Remove 2.1 media types

### DIFF
--- a/doc/availability.md
+++ b/doc/availability.md
@@ -138,10 +138,10 @@ The following media types can be used with _availability_ queries:
 
 - **application/vnd.sdmx.structure+json;version=2.0.0**
 - application/vnd.sdmx.structure+xml;version=3.0.0
-- application/vnd.sdmx.structure+xml;version=2.1
-- application/vnd.sdmx.structure+json;version=1.0.0
 
 The default format is highlighted in **bold**.
+
+For media types of previous SDMX versions, please consult the documentation of the SDMX version you are interested in.
 
 ## Examples
 

--- a/doc/data.md
+++ b/doc/data.md
@@ -54,14 +54,8 @@ The following media types can be used with _data_ queries:
 - **application/vnd.sdmx.data+json;version=2.0.0**
 - application/vnd.sdmx.data+xml;version=3.0.0
 - application/vnd.sdmx.data+csv;version=2.0.0;labels=[id|name|both];timeFormat=[original|normalized];keys=[none|obs|series|both]
-- application/vnd.sdmx.genericdata+xml;version=2.1
-- application/vnd.sdmx.structurespecificdata+xml;version=2.1
-- application/vnd.sdmx.generictimeseriesdata+xml;version=2.1
-- application/vnd.sdmx.structurespecifictimeseriesdata+xml;version=2.1
-- application/vnd.sdmx.data+json;version=1.0.0
-- application/vnd.sdmx.data+csv;version=1.0.0;labels=[id|both];timeFormat=[original|normalized]
 
-The default format is highlighted in **bold**.
+The default format is highlighted in **bold**. For media types of previous SDMX versions, please consult the documentation of the SDMX version you are interested in.
 
 SDMX-CSV offers the possibility to set the value for two parameters via the media-type. These parameters are `label` and `timeFormat`; both are optional. The default values for these parameters are marked with * in the above media-type (i.e. `id` and `original` respectively). For additional information about these parameters, please refer to the [SDMX-CSV specification](https://sdmx.org/?sdmx_news=sdmx-csv-format-specifications-just-released).
 

--- a/doc/metadata.md
+++ b/doc/metadata.md
@@ -105,8 +105,6 @@ The following media types can be used with _reference metadata_ queries:
 
 - **application/vnd.sdmx.metadata+json;version=2.0.0**
 - application/vnd.sdmx.metadata+xml;version=3.0.0
-- application/vnd.sdmx.metadata+csv;version=1.0.0
-- application/vnd.sdmx.genericmetadata+xml;version=2.1
-- application/vnd.sdmx.structurespecificmetadata+xml;version=2.1
+- application/vnd.sdmx.metadata+csv;version=2.0.0
 
-The default format is highlighted in **bold**.
+The default format is highlighted in **bold**. For media types of previous SDMX versions, please consult the documentation of the SDMX version you are interested in.

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -24,15 +24,12 @@ Note: Mandatory parameters are highlighted in **bold**.
 
 The following media types can be used with _schema_ queries:
 
-- **application/vnd.sdmx.schema+json;version=3.0.0**
+- **application/vnd.sdmx.schema+json;version=2.0.0**
 - application/vnd.sdmx.schema+xml;version=3.0.0
 - application/vnd.sdmx.structure+xml;version=3.0.0
 - application/vnd.sdmx.structure+json;version=2.0.0
-- application/vnd.sdmx.schema+xml;version=2.1
-- application/vnd.sdmx.structure+xml;version=2.1
-- application/vnd.sdmx.structure+json;version=1.0.0
 
-The default format is highlighted in **bold**.
+The default format is highlighted in **bold**. For media types of previous SDMX versions, please consult the documentation of the SDMX version you are interested in.
 
 The _schema_ formats are meant to be used for **validation** purposes (i.e. to validate SDMX-ML and SDMX-JSON data files).
 

--- a/doc/structures.md
+++ b/doc/structures.md
@@ -150,11 +150,9 @@ For example, a dataflow only references a data structure definition and, in addi
 The following media types can be used with _structure_ queries:
 
 - **application/vnd.sdmx.structure+json;version=2.0.0**
-- application/vnd.sdmx.structure+json;version=1.0.0
 - application/vnd.sdmx.structure+xml;version=3.0.0
-- application/vnd.sdmx.structure+xml;version=2.1
 
-The default format is highlighted in **bold**.
+The default format is highlighted in **bold**. For media types of previous SDMX versions, please consult the documentation of the SDMX version you are interested in.
 
 ## Examples of queries
 


### PR DESCRIPTION
This PR removes the 2.1 media types and adds a note about where these previous versions can be found