### PR TITLE
Add a hint on how to retrieve previous versions of the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ This repository contains:
 
 - The normative part of the specification, i.e. the [Open API definition](api/sdmx-rest.yaml).
 - The [Developers' documentation](doc/index.md), including a [cheat sheet](doc/rest_cheat_sheet.pdf?raw=true).
+
+> [!TIP]
+> Each release of the SDMX-REST API is associated with a tag. Retrieving **previous versions** of the SDMX-REST API (Open API definition, cheatsheet, documentation, etc.) is
+> easy, using either **tags** or **releases**:
+>
+> * **tags**: Tags can be used to retrieve the Open API definition, cheatsheet and documentation of a specific version of the SDMX-REST API. Tags are located towards the top of this page.
+> * **releases**: Releases are located in the navigation bar on the right of this page. They too can be used to retrieve the Open API definition, cheatsheet and documentation of a specific version of the SDMX-REST API.


### PR DESCRIPTION
This addresses issue #179