### PR TITLE
Minor changes to asOf feature

### DIFF
--- a/doc/data.md
+++ b/doc/data.md
@@ -8,7 +8,7 @@ Data queries allow **retrieving statistical data**. Entire datasets, individual 
 
     protocol://ws-entry-point/data/{context}/{agencyID}/{resourceID}/{version}/{key}?
     {c}&{updatedAfter}&{firstNObservations}&{lastNObservations}&{dimensionAtObservation}
-    &{attributes}&{measures}&{includeHistory}&{offset}&{limit}&{sort}
+    &{attributes}&{measures}&{includeHistory}&{offset}&{limit}&{sort}&asOf
 
 Parameter | Type | Description | Default | Multiple values?
 --- | --- | --- | --- | ---
@@ -28,7 +28,7 @@ includeHistory | Boolean | This parameter allows retrieving previous versions of
 offset | Positive integer | The number of observations (or series keys) to skip before beginning to return observations (or series keys). | 0 | No
 limit | Positive integer | The maximum number of observations (or series keys) to be returned. If no limit is set, all matching observations (or series keys) must be returned. | | No
 sort | String | This parameter specifies the order in which the returned data should be sorted. It contains either one or more component IDs, by which the data should be sorted, separated by `+` (to indicate an AND), the `*` operator, which represents all dimensions as positioned in the DSD, or the keyword `series_key`, which represents, when `dimensionAtObservation` is not equal to `AllDimensions`, all dimensions not presented at the observational level and as positioned in the DSD. The sorting must respect the sequence, in which the components are listed. In addition, each component, or the set of components (through the operator or keyword) can be sorted in ascending or descending order by appending `:asc` or `:desc`, with `:asc` being the default. For any component not included in the sort parameter, the related order is non-deterministic. Except for time periods, which have a natural chronological order, the sorting within a component is based on the code IDs or the non-coded component values. | | No
-asOf | xs:dateTime | Retrieve the data as they were at the specified point in time (aka time travel). In case both `updatedAfter` and `asOf` are set, the service is expected to return a validation error if `updatedAfter` is more recent than `asOf`. | | No
+asOf | xs:dateTime | Retrieve the data as they were at the specified point in time (aka time travel). In case both `updatedAfter` and `asOf` are set, the service is expected to return a client error if `updatedAfter` is more recent than `asOf`. | | No
 
 The following rules apply:
 

--- a/doc/metadata.md
+++ b/doc/metadata.md
@@ -8,15 +8,14 @@ These queries enable clients to find metadatasets by the identification of the m
 
 ### Syntax
 
-    protocol://ws-entry-point/metadata/metadataset/{providerID}/{metadatasetID}/{version}?{detail}
+    protocol://ws-entry-point/metadata/metadataset/{providerID}/{metadatasetID}/{version}?{detail}&{asOf}
 
 Parameter | Type | Description | Default | Multiple values
 --- | --- | --- | --- | ---
 providerID | A string compliant with the SDMX _common:NestedNCNameIDType_ for MetadataProvider | The id of the data provider who maintains the metadata set.  It is possible to set more than one id, using `,` as separator (e.g. UK1,UK2) | * | Yes
 metadatasetID | A string compliant with the SDMX _common:NestedNCNameIDType_ for MetadataSet | The Id of the metadata set to be returned.  It is possible to set more than one id, using `,` as separator (e.g. MS1,MS2) | * | Yes
 version | A string compliant with the [SDMX *semantic versioning* rules](querying_versions.md) | The version of the artefact to be returned. It is possible to set more than one version, using `,` as separator (e.g. 1.0.0,2.1+.7). | ~ | Yes
-detail | *String* | This attribute specifies the desired amount of information to be returned. For example, it is possible to instruct the web service to return only basic information about the metadataset  (i.e.: id, dataprovider id, version and name). Most notably, metadata attributes of a metadataset  will not be returned Possible values are: (1) `full`: all available information for all returned metadatasets should be returned. (2) `allstubs`: all returned metadatasets should be returned as stubs, i.e. only containing identification information and the metadataset' name. | 
-**full** | No
+detail | *String* | This attribute specifies the desired amount of information to be returned. For example, it is possible to instruct the web service to return only basic information about the metadataset  (i.e.: id, dataprovider id, version and name). Most notably, metadata attributes of a metadataset  will not be returned Possible values are: (1) `full`: all available information for all returned metadatasets should be returned. (2) `allstubs`: all returned metadatasets should be returned as stubs, i.e. only containing identification information and the metadataset' name. | **full** | No
 asOf | xs:dateTime | Retrieve the metadata set as it was at the specified point in time (aka time travel). | | No
 
 Notes:
@@ -41,7 +40,7 @@ These queries enable clients to find metadatasets by the collection (metadataflo
 
 ### Syntax
 
-    protocol://ws-entry-point/metadata/metadataflow/{flowAgencyID}/{flowID}/{flowVersion}/{providerRef}?{detail}
+    protocol://ws-entry-point/metadata/metadataflow/{flowAgencyID}/{flowID}/{flowVersion}/{providerRef}?{detail}&{asOf}
 
 Parameter | Type | Description | Default | Multiple values
 --- | --- | --- | --- | ---
@@ -74,7 +73,7 @@ These queries enable clients to request all metadata sets which are reported aga
 
 ### Syntax
 
-    protocol://ws-entry-point/metadata/structure/{artefactType}/{agencyID}/{resourceID}/{version}?{detail}
+    protocol://ws-entry-point/metadata/structure/{artefactType}/{agencyID}/{resourceID}/{version}?{detail}&{asOf}
 
 Parameter | Type | Description | Default | Multiple values?
 --- | --- | --- | --- | ---

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -8,7 +8,7 @@ This is typically used for **validation and/or communication purposes**, for exa
 
 ## Syntax
 
-    protocol://ws-entry-point/schema/{context}/{agencyID}/{resourceID}/{version}?{dimensionAtObservation}&{deletion}
+    protocol://ws-entry-point/schema/{context}/{agencyID}/{resourceID}/{version}?{dimensionAtObservation}&{deletion}&{asOf}
 
 Parameter | Type | Description | Default
 --- | --- | --- | ---

--- a/doc/structures.md
+++ b/doc/structures.md
@@ -15,11 +15,11 @@ Structure queries in SDMX allow you to retrieve structural metadata at various l
 
 ## Syntax
 
-        protocol://ws-entry-point/structure/{artefactType}/{agencyID}/{resourceID}/{version}?{detail}&{references}
+        protocol://ws-entry-point/structure/{artefactType}/{agencyID}/{resourceID}/{version}?{detail}&{references}&{asOf}
 
 For item schemes, an additional path parameter (itemID) is permissible.
 
-        protocol://ws-entry-point/structure/{artefactType}/{agencyID}/{resourceID}/{version}/{itemID}?{detail}&{references}
+        protocol://ws-entry-point/structure/{artefactType}/{agencyID}/{resourceID}/{version}/{itemID}?{detail}&{references}&{asOf}
 
 Parameter | Type | Description | Default | Multiple values?
 --- | --- | --- | --- | ---


### PR DESCRIPTION
This PR contains 2 sets of changes:

- It leaves the choice of the error code to be returned to the implementer, following a [discussion](https://github.com/sdmx-twg/sdmx-rest/issues/157#issuecomment-2338313944) with @dosse.
- It adds the `asOf` parameters to the URLs in the documentation, as this had been forgotten.