### PR TITLE
Add examples for queries with the c filter

### DIFF
--- a/doc/data.md
+++ b/doc/data.md
@@ -52,6 +52,21 @@ ew | Ends with |
 
 Operators appear as prefix to the component value(s) and are separated from it by a `:` (e.g. `c[TIME_PERIOD]=ge:2020-01+le:2020-12`).
 
+The table below offers a few examples and how they should be interpreted.
+
+| Example | Meaning |
+| --- | --- | 
+|c[X]=A |X = A|
+|c[X]=A,B |X = A OR X = B|
+|c[X]=ge:A |X >= A|
+|c[X]=ge:A+le:B |X >= A AND X <= B|
+|c[X]=A,B+C |X = A OR (X = B AND X = C)|
+|c[X]=ge:A+le:B,ge:C+le:D |(X >= A AND X <= B) OR (X >= C AND X <= D)|
+|c[X]=ne:A,B |X <> A OR X = B|
+|c[X]=ne:A+B |X <> A AND X = B|
+|c[X]=ne:A,ne:B |X <> A OR X <> B|
+|c[X]=ne:A+ne:B |X <> A AND X <> B|
+
 ## Response types
 
 The following media types can be used with _data_ queries:


### PR DESCRIPTION
Following discussions with implementers, I thought it would be useful to add examples using the c filter, and how they should be interpreted.