### PR TITLE
docs: add repository structure and versioning sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,29 @@ This repository contains:
 >
 > * **tags**: Tags can be used to retrieve the Open API definition, cheatsheet and documentation of a specific version of the SDMX-REST API. Tags are located towards the top of this page.
 > * **releases**: Releases are located in the navigation bar on the right of this page. They too can be used to retrieve the Open API definition, cheatsheet and documentation of a specific version of the SDMX-REST API.
+
+## Repository Structure
+
+-   `docs/` — Markdown content pages for the REST API and registry
+    specification documentation.
+-   `api/sdmx-rest.yaml` — normative OpenAPI definition.
+
+| File                                | Section served          |
+| ----------------------------------- | ----------------------- |
+| `mkdocs_rest_api.yml`               | REST API documentation  |
+| `mkdocs_registry_specification.yml` | Registry specification  |
+
+## Version Branches
+
+Each release of this component is maintained on a dedicated branch following the
+pattern `X.Y.x` (e.g., `2.2.x`). The branch tracked by the
+[`sdmx-docs`](https://github.com/sdmx-twg/sdmx-docs) parent repository is
+declared in `.gitmodules` at the root of that repo. Switching the tracked branch
+in the parent repository is how a new version of this component is published on
+the documentation site.
+
+## Formatting Conventions
+
+For Markdown and MkDocs formatting conventions that apply to content in `docs/`,
+see the [`sdmx-docs` README](https://github.com/sdmx-twg/sdmx-docs#readme).
+


### PR DESCRIPTION
Append Repository Structure (docs/, api/sdmx-rest.yaml, config files), Version Branches, and Formatting Conventions sections to align with the shared submodule README template used across sdmx-docs components.