### PR TITLE
Improve status codes

### DIFF
--- a/doc/status.md
+++ b/doc/status.md
@@ -1,22 +1,23 @@
 # Error handling and status information
 
-RESTful web services use HTTP status codes to indicate errors. In principle, any [code defined by HTTP](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) can therefore be returned by an SDMX RESTful web service but a few of the most common ones are described below.
+RESTful web services rely on HTTP status codes to indicate the outcome of requests, including errors. While an SDMX RESTful web service can return any [HTTP-defined status code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes), the most commonly used codes are described below.
 
-Codes below 400 are considered normal (i.e. non-problematic). Codes between 400 and 499 are considered client errors. Codes greater or equal to 500 indicate a server error or problem.
+- **Codes below 400**: Indicate successful or normal operations (non-problematic).
+- **Codes between 400 and 499**: Indicate client errors.
+- **Codes 500 and above**: Indicate server errors.
 
 HTTP status code | Description
 ---|---
-200 | This is the standard response for successful HTTP requests. With `GET` requests, it is used to indicate that the request was successfully processed and that the data are available in the body of the response.
-204 | If the result from the query is empty, and this lack of results is considered acceptable.
-304 | This is used to indicate that there are no changes since the version specified by the request headers `If-Modified-Since` or `If-None-Match`. The response does not include matching data, as the data downloaded previously is still valid.
-400 | This error code is used when the query doesn’t comply with the SDMX REST API.
-401 | For use when authentication is needed but has failed or has not yet been provided.
-403 | For use when authentication has been provided correctly, but user is not authorized to access the query results.
-404 | If the requested resource is not available.
-406 | If a client asks for a resource representation that the web service does not offer, a 406 HTTP status code should be returned.
-413 | The request would result in a response that is larger than the server is willing or able to process. In case the service offers the possibility to users to download the results of large queries at a later stage (for instance, using asynchronous web services), the web service may choose to indicate the (future) location of the file, as part of the error message.
-414 | This status code (URI Too Long) indicates that the server is refusing to service the request because the request-target is longer than the server is willing to interpret. See [the wiki page for information on the URL length](https://github.com/sdmx-twg/sdmx-rest/wiki/URL-length-in-REST).
-422 | A web service should return this error when a request is syntactically correct but fails a semantic validation or violates agreed business rules.
-500 | The web service should return this error code when none of the other error codes better describes the reason for the failure of the service to provide a meaningful response.
-501 | All SDMX web services should implement all the standard interfaces, even if their only function is to return this error message. This eases interoperability between SDMX compliant web services and it also eases the development of generic SDMX web services clients. If the web service has not yet implemented one of the methods defined in the API, then it should return this error.
-503 | If a web service is temporarily unavailable because of maintenance or for some other similar reasons, then it should return this error code.
+200 | A successful HTTP request. For GET requests, it means the request was successfully processed, and the response body contains the requested data.
+204 | The query result is empty, but this lack of results is acceptable.
+304 | No changes since the version specified by the request headers (If-Modified-Since or If-None-Match). The response does not include data, as previously downloaded data is still valid.
+400 | The query does not comply with the SDMX-REST API.
+401 | Authentication is required but has failed or has not been provided.
+403 | Authentication was successful, but the user is not authorized to access the requested resource.
+404 | The requested resource is not available.
+406 | The client requested a resource representation that the web service does not offer.
+413 | The requested response is too large for the server to process. If the service supports downloading large queries asynchronously, it may provide the future location of the file in the error message.
+422 | The request is syntactically correct but fails semantic validation or violates agreed business rules.
+500 | The server cannot provide a meaningful response due to an unexpected error.
+501 | The web service has not implemented a specific method defined in the API. Returning this code ensures interoperability and simplifies the development of generic SDMX web service clients.
+503 | The service is temporarily unavailable, such as during maintenance.

--- a/doc/status.md
+++ b/doc/status.md
@@ -1,6 +1,6 @@
 # Error handling and status information
 
-RESTful web services rely on HTTP status codes to indicate the outcome of requests, including errors. While an SDMX RESTful web service can return any [HTTP-defined status code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes), the most commonly used codes are described below.
+RESTful web services rely on HTTP status codes to indicate the outcome of requests, including errors. While an SDMX RESTful web service can return any [HTTP-defined status code](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml), the most commonly used codes are described below.
 
 - **Codes below 400**: Indicate successful or normal operations (non-problematic).
 - **Codes between 400 and 499**: Indicate client errors.

--- a/doc/status.md
+++ b/doc/status.md
@@ -7,11 +7,12 @@ Codes below 400 are considered normal (i.e. non-problematic). Codes between 400 
 HTTP status code | Description
 ---|---
 200 | This is the standard response for successful HTTP requests. With `GET` requests, it is used to indicate that the request was successfully processed and that the data are available in the body of the response.
-204 | If the result from the query is empty, the web service should return this code. `204` is preferred to `404` in this case, as a lack of results matching a query is an “empty but still healthy state”.
+204 | If the result from the query is empty, and this lack of results is considered acceptable.
 304 | This is used to indicate that there are no changes since the version specified by the request headers `If-Modified-Since` or `If-None-Match`. The response does not include matching data, as the data downloaded previously is still valid.
 400 | This error code is used when the query doesn’t comply with the SDMX REST API.
 401 | For use when authentication is needed but has failed or has not yet been provided.
 403 | For use when authentication has been provided correctly, but user is not authorized to access the query results.
+404 | If the requested resource is not available.
 406 | If a client asks for a resource representation that the web service does not offer, a 406 HTTP status code should be returned.
 413 | The request would result in a response that is larger than the server is willing or able to process. In case the service offers the possibility to users to download the results of large queries at a later stage (for instance, using asynchronous web services), the web service may choose to indicate the (future) location of the file, as part of the error message.
 414 | This status code (URI Too Long) indicates that the server is refusing to service the request because the request-target is longer than the server is willing to interpret. See [the wiki page for information on the URL length](https://github.com/sdmx-twg/sdmx-rest/wiki/URL-length-in-REST).

--- a/doc/status.md
+++ b/doc/status.md
@@ -10,7 +10,7 @@ HTTP status code | Description
 ---|---
 200 | A successful HTTP request. For GET requests, it means the request was successfully processed, and the response body contains the requested data.
 204 | The query result is empty, but this lack of results is acceptable.
-304 | No changes since the version specified by the request headers (If-Modified-Since or If-None-Match). The response does not include data, as previously downloaded data is still valid.
+304 | No changes since the version specified by the request headers `If-Modified-Since` or `If-None-Match`. The response does not include data, as previously downloaded data is still valid.
 400 | The query does not comply with the SDMX-REST API.
 401 | Authentication is required but has failed or has not been provided.
 403 | Authentication was successful, but the user is not authorized to access the requested resource.

--- a/doc/tips.md
+++ b/doc/tips.md
@@ -42,7 +42,7 @@ Plain text formats (XML, JSON, CSV, etc.) compress very well. Compressed data ar
 
 ### Check the response status code
 
-The response status code is used to report potential issues. So, check it. It’s not always 200 (or 42). See the section about the [status codes](status.md) for additional information.
+The response status code is used to report potential issues. So, check it. It’s not always 200 (or 42). See the section about the [status codes](status.md) for additional information, and keep in mind that additional status codes are allowed in HTTP. Also, be ready to accept both `204` and `404` to indicate that there is nothing matching your request. Some might even return `501` to indicate they don't support a certain type of artefact. Likewise, remember that some services might have generic "fallback" error codes such as `400` for any client error and `500` for any service error.
 
 ## Tips for data providers
 


### PR DESCRIPTION
Close #275 
Close #279 

The purpose of this PR is to clarify status code usage, without being too prescriptive. This primarily affects how we report that something is not available (`204` vs. `404` vs. `501`), but also touches upon "umbrella" codes.